### PR TITLE
Certs can now have subject alternative names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To create a new CA, create variables file with subject description:
 ```RUBY
 create_ca       = true
 ca_cert_subject = {
-    common_name         = "example.com"
+    common_name         = "My Org Root CA"
     organization        = "My org"
     organizational_unit = "Org department"
     street_address      = ["1 Dundas str"]
@@ -15,15 +15,16 @@ ca_cert_subject = {
     province            = "ON"
     country             = "CA"
     postal_code         = "111-222"
-    serial_number       = null
+    serial_number       = 1000
 }
 ```
 
-you can also add optional `client_cert_subjects` variable with a list of subjects for certificates issue:
+add one or more subjects for the sertificates you want to issue into `client_cert_subjects` variable:
 
 ```RUBY
 client_cert_subjects = [{
   common_name         = "website.local"
+  alternative_names   = ["website.local","www.website.local"]
   organization        = "My org"
   organizational_unit = "Org unit"
   street_address      = ["Some address"]
@@ -31,10 +32,11 @@ client_cert_subjects = [{
   province            = "ON"
   country             = "CA"
   postal_code         = "112-221"
-  serial_number       = null
+  serial_number       = 1001
 },
 {
   common_name         = "localhost"
+  alternative_names   = ["localhost"]
   organization        = "My org"
   organizational_unit = "Org unit"
   street_address      = ["Some address"]
@@ -42,7 +44,7 @@ client_cert_subjects = [{
   province            = "ON"
   country             = "CA"
   postal_code         = "112-221"
-  serial_number       = null
+  serial_number       = 1002
 }]
 ```
 
@@ -64,6 +66,8 @@ ca_pkey_file = "ca.key"
 There are number of additional options you can set, please refer to the *variables.tf* file for complete list.
 
 ## Run it
+
+Obviously you will need [terraform](https://www.terraform.io/downloads.html) binary to run this script. The minimum version needed is 0.12.0.
 
 Assuming that variables are in *main.tfvars* file
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "ca" {
 locals {
   client = [for i in range(length(var.client_cert_subjects)) : {
     name = replace(var.client_cert_subjects[i]["common_name"], "*", "all")
-    cert = module.ca.client_cert[i],
+    cert = module.ca.client_certs[i],
     pkey = module.ca.client_private_key[i]
   }]
 }

--- a/main.tfvars
+++ b/main.tfvars
@@ -1,38 +1,27 @@
-# Put your variables here
+create_ca = true
 
-# create_ca       = true
+ca_cert_subject = {
+  common_name         = "Trollab Root CA"
+  organization        = "Trollab"
+  street_address      = ["309-3089 Jaguar Valley Drive"]
+  locality            = "Mississauga"
+  province            = "ON"
+  country             = "CA"
+  postal_code         = "L5A-2J1"
+  serial_number       = 1001
+}
 
-# ca_cert_subject = {
-#   common_name         = ""
-#   organization        = ""
-#   organizational_unit = ""
-#   street_address      = ["""]
-#   locality            = ""
-#   province            = ""
-#   country             = ""
-#   postal_code         = ""
-#   serial_number       = null
-# }
-
-# client_cert_subjects = [{
-#   common_name         = ""
-#   organization        = ""
-#   organizational_unit = ""
-#   street_address      = ["""]
-#   locality            = ""
-#   province            = ""
-#   country             = ""
-#   postal_code         = ""
-#   serial_number       = null
-#   },
-#   {
-#   common_name         = ""
-#   organization        = ""
-#   organizational_unit = ""
-#   street_address      = ["""]
-#   locality            = ""
-#   province            = ""
-#   country             = ""
-#   postal_code         = ""
-#   serial_number       = null
-# }]
+client_cert_subjects = [
+  {
+    common_name         = "laptop.trollab.ca"
+    alternative_names   = ["laptop.trollab.ca"]
+    organization        = "Trollab"
+    organizational_unit = "DevOps"
+    street_address      = ["309-3089 Jaguar Valley Drive"]
+    locality            = "Mississauga"
+    province            = "ON"
+    country             = "CA"
+    postal_code         = "L5A-2J1"
+    serial_number       = 1004
+  }
+]

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -37,6 +37,7 @@ resource "tls_cert_request" "client" {
   count           = length(var.client_cert_subjects)
   key_algorithm   = tls_private_key.client[count.index].algorithm
   private_key_pem = tls_private_key.client[count.index].private_key_pem
+  dns_names       = lookup(var.client_cert_subjects[count.index], "alternative_names", null)
   subject {
     common_name         = lookup(var.client_cert_subjects[count.index], "common_name", null)
     country             = lookup(var.client_cert_subjects[count.index], "country", null)

--- a/modules/ca/outputs.tf
+++ b/modules/ca/outputs.tf
@@ -6,7 +6,7 @@ output "ca_pkey" {
   value = tls_private_key.root.0.private_key_pem
 }
 
-output "client_cert" {
+output "client_certs" {
   value = tls_locally_signed_cert.client.*.cert_pem
 }
 

--- a/modules/ca/variables.tf
+++ b/modules/ca/variables.tf
@@ -59,19 +59,7 @@ variable "ca_cert_early_renewal_hours" {
 }
 
 variable "ca_cert_subject" {
-  type        = object({
-    common_name         = string
-    organization        = string
-    organizational_unit = string
-    street_address      = list(string)
-    locality            = string
-    province            = string
-    country             = string
-    postal_code         = string
-    serial_number       = string
-  })
   description = "The subject for which a certificate is being requested."
-  default     = null
 }
 
 variable "client_key_ecdsa_curve" {
@@ -81,9 +69,7 @@ variable "client_key_ecdsa_curve" {
 }
 
 variable "client_cert_subjects" {
-  type        = list
   description = "The subject for which a certificate is being requested."
-  default     = []
 }
 
 variable "client_cert_validity_period" {

--- a/variables.tf
+++ b/variables.tf
@@ -59,19 +59,7 @@ variable "ca_cert_early_renewal_hours" {
 }
 
 variable "ca_cert_subject" {
-  type = object({
-    common_name         = string
-    organization        = string
-    organizational_unit = string
-    street_address      = list(string)
-    locality            = string
-    province            = string
-    country             = string
-    postal_code         = string
-    serial_number       = string
-  })
   description = "The subject for which a certificate is being requested."
-  default     = null
 }
 
 variable "client_key_ecdsa_curve" {
@@ -81,9 +69,7 @@ variable "client_key_ecdsa_curve" {
 }
 
 variable "client_cert_subjects" {
-  type        = list
   description = "The subject for which a certificate is being requested."
-  default     = []
 }
 
 variable "client_cert_validity_period" {


### PR DESCRIPTION
With SAN set to match common name, Chrome browser will recognize them as secure, assuming that CA cert was properly imported into system keychain and marked as trusted.